### PR TITLE
ECMAScript Modules and Client Isolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ app.use('/images', express.static(path.join(process.env.DATABASE, 'images')))
 app.use(api(db, xmltvInterval))
 app.use(video(db))
 app.use(hdhr.router)
-app.use('/driver', driverRouter);
+app.use('/api/driver', driverRouter);
 app.listen(process.env.PORT, () => {
     console.log(`HTTP server running on port: http://*:${process.env.PORT}`)
     let hdhrSettings = db['hdhr-settings'].find()[0]

--- a/index.js
+++ b/index.js
@@ -1,15 +1,19 @@
-const db = require('diskdb')
-const fs = require('fs')
-const path = require('path')
-const express = require('express')
-const bodyParser = require('body-parser')
+import db from 'diskdb';
+import * as fs from 'fs';
+import * as path from 'path';
+import express from 'express';
+import bodyParser from 'body-parser';
 
-const api = require('./src/api')
-const video = require('./src/video')
-const HDHR = require('./src/hdhr')
+import api from './src/api.js';
+import video from './src/video.js';
+import HDHR from './src/hdhr.js';
+import driverRouter from './src/routers/driverRouter.js';
 
-const xmltv = require('./src/xmltv')
-const Plex = require('./src/plex')
+import xmltv from './src/xmltv.js';
+import * as Plex from './src/plex.js';
+
+const __dirname = path.resolve(path.dirname(''));
+
 
 for (let i = 0, l = process.argv.length; i < l; i++) {
     if ((process.argv[i] === "-p" || process.argv[i] === "--port") && i + 1 !== l)
@@ -78,9 +82,10 @@ let app = express()
 app.use(bodyParser.json({limit: '50mb'}))
 app.use(express.static(path.join(__dirname, 'web/public')))
 app.use('/images', express.static(path.join(process.env.DATABASE, 'images')))
-app.use(api.router(db, xmltvInterval))
-app.use(video.router(db))
+app.use(api(db, xmltvInterval))
+app.use(video(db))
 app.use(hdhr.router)
+app.use('/driver', driverRouter);
 app.listen(process.env.PORT, () => {
     console.log(`HTTP server running on port: http://*:${process.env.PORT}`)
     let hdhrSettings = db['hdhr-settings'].find()[0]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2715,6 +2715,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "angular-router-browserify": "0.0.2",
     "body-parser": "^1.19.0",
     "diskdb": "^0.1.17",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "node-ssdp": "^4.0.0",
     "request": "^2.88.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Create LiveTV channels from your Plex media",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js",

--- a/src/api.js
+++ b/src/api.js
@@ -1,9 +1,8 @@
 
-const express = require('express')
-const fs = require('fs')
+import express from 'express';
+import * as fs from 'fs';
 
-module.exports = { router: api }
-function api(db, xmltvInterval) {
+export default function api(db, xmltvInterval) {
     let router = express.Router()
 
     // Plex Servers

--- a/src/database.js
+++ b/src/database.js
@@ -1,0 +1,18 @@
+import db from 'diskdb';
+import dotenv from 'dotenv';
+dotenv.config();
+
+process.env.DATABASE = process.env.DATABASE || './.pseudotv';
+
+db.connect(process.env.DATABASE, ['channels', 'media-servers', 'ffmpeg-settings', 'xmltv-settings', 'hdhr-settings']);
+
+export class Database {
+    constructor(tableName) {
+        this.tableName = tableName;
+    }
+
+    save(data) {
+        db[this.tableName].save(data);
+        return db[this.tableName].find();
+    }
+}

--- a/src/driver.js
+++ b/src/driver.js
@@ -1,22 +1,48 @@
 import { Plex } from './plex.js';
 
 export class Driver {
-    constructor(){}
+    constructor(){
+        this.plex = new Plex({});
+    }
 
-    getLibrary(option) {
-        try {
-            if(option) {
+    
+    login(option = { service: null, host: null }) {
+        return new Promise(async (resolve, reject) => {
+            try {
                 switch(option.service) {
                     case 'plex':
+                        console.log(option);
+                        resolve(await this.plex.Login(option.host));
                         break;
                     default: 
-                        new Error('This service is not compatible')
+                        reject('This service is not compatible');
                 }
-            } else {
-                new Error('You need to set a service.')
+            } catch (error) {
+                reject(error.message);
             }
-        } catch (error) {
-            
-        }
+        });
+    }
+
+    /**
+     *
+     *
+     * @param {*} option {service: plex}
+     * @memberof Driver
+     */
+    getLibrary(option = { service: null }) {
+        return new Promise((resolve, reject) => {
+            try {
+                switch(option.service) {
+                    case 'plex':
+                        console.log(this.plex.GetLibrary());
+                        resolve('Ok');
+                        break;
+                    default: 
+                        reject('This service is not compatible');
+                }
+            } catch (error) {
+                reject(error.message);
+            }
+        });
     }
 }

--- a/src/driver.js
+++ b/src/driver.js
@@ -1,0 +1,22 @@
+import { Plex } from './plex.js';
+
+export class Driver {
+    constructor(){}
+
+    getLibrary(option) {
+        try {
+            if(option) {
+                switch(option.service) {
+                    case 'plex':
+                        break;
+                    default: 
+                        new Error('This service is not compatible')
+                }
+            } else {
+                new Error('You need to set a service.')
+            }
+        } catch (error) {
+            
+        }
+    }
+}

--- a/src/errorResponse.js
+++ b/src/errorResponse.js
@@ -1,0 +1,17 @@
+export class ErrorResponse {
+    /**
+     * Format error to response for client.
+     * Return a translated message.
+     *
+     * @static
+     * @param {*} options { code: number; message: string; }
+     * @returns
+     * @memberof ErrorResponse
+     */
+    static errorMessage(options = { code: 0, message: '' }) {
+        return {
+            code: options.code,
+            message: options.message
+        }
+    }
+}

--- a/src/ffmpeg.js
+++ b/src/ffmpeg.js
@@ -1,8 +1,8 @@
-const spawn = require('child_process').spawn
-const events = require('events')
-const fs = require('fs')
+import { spawn } from 'child_process';
+import * as events from 'events';
+import * as fs from 'fs';
 
-class FFMPEG extends events.EventEmitter {
+export default class FFMPEG extends events.EventEmitter {
     constructor(opts, channel) {
         super()
         this.offset = 0
@@ -172,5 +172,3 @@ class FFMPEG extends events.EventEmitter {
         this.ffmpeg.kill()
     }
 }
-
-module.exports = FFMPEG

--- a/src/ffmpegText.js
+++ b/src/ffmpegText.js
@@ -1,9 +1,7 @@
-const spawn = require('child_process').spawn
-const events = require('events')
-const fs = require('fs')
-const path = require('path')
+import { spawn } from 'child_process';
+import * as events from 'events';
 
-class FFMPEG_TEXT extends events.EventEmitter {
+export default class FFMPEG_TEXT extends events.EventEmitter {
     constructor (opts, title, subtitle) {
         super()
         this.args = [
@@ -48,5 +46,3 @@ class FFMPEG_TEXT extends events.EventEmitter {
         this.ffmpeg.kill()
     }
 }
-
-module.exports = FFMPEG_TEXT

--- a/src/hdhr.js
+++ b/src/hdhr.js
@@ -1,11 +1,9 @@
-const express = require('express')
-const SSDP = require('node-ssdp').Server
+import express from 'express';
+import SsdpServer from 'node-ssdp/lib/server.js';
 
-module.exports = hdhr
+export default function hdhr(db) {
 
-function hdhr(db) {
-
-    const server = new SSDP({
+    const server = new SsdpServer({
         location: {
             port: process.env.PORT,
             path: '/device.xml'
@@ -73,7 +71,7 @@ function getDevice(db, host) {
         LineupURL: `${host}/lineup.json`
     }
     device.getXml = () => {
-        str =
+        const str =
             `<root xmlns="urn:schemas-upnp-org:device-1-0">
       <URLBase>${device.BaseURL}</URLBase>
       <specVersion>

--- a/src/helperFuncs.js
+++ b/src/helperFuncs.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     getCurrentProgramAndTimeElapsed: getCurrentProgramAndTimeElapsed,
     createLineup: createLineup
 }

--- a/src/plex.js
+++ b/src/plex.js
@@ -1,5 +1,5 @@
-const request = require('request')
-class Plex {
+import * as request from 'request';
+export class Plex {
     constructor(opts) {
         this._token = typeof opts.token !== 'undefined' ? opts.token : ''
         this._server = {
@@ -139,5 +139,3 @@ class Plex {
                 this.Put(`/media/grabbers/devices/${dvrs[i].Device[y].key}/channelmap`, qs).then(() => { }, (err) => { console.log(err) })
     }
 }
-
-module.exports = Plex

--- a/src/routers/driverRouter.js
+++ b/src/routers/driverRouter.js
@@ -1,4 +1,5 @@
 import { Driver } from '../driver.js';
+import { ErrorResponse } from '../errorResponse.js';
 
 import express from 'express';
 const router = express.Router();
@@ -9,12 +10,46 @@ function getDrivers(req, res) {
     res.send(['plex']);
 }
 
-function getLibrary(req, res) {
-    res.send('xxxx');
+async function getLibrary(req, res) {
+    try {
+        const library = await driver.getLibrary({
+            service: req.query.service
+        });
+        res.send(library);
+    } catch (error) {
+        res.send(
+            ErrorResponse.errorMessage({
+                code: 10001,
+                message: error
+            })
+        );
+    }
+}
+
+async function login(req, res) {
+    try {
+        const login = await driver.login({
+            service: req.query.service,
+            host: {
+                protocol: 'http',
+                host: '192.168.25.11',
+                port: '32400'
+            }
+        });
+        res.send(login);
+    } catch (error) {
+        res.send(
+            ErrorResponse.errorMessage({
+                code: 10001,
+                message: error
+            })
+        );
+    }
 }
 
 // Routes
 router.get('/', getDrivers);
 router.get('/library', getLibrary);
+router.get('/login', login);
 
 export default router;

--- a/src/routers/driverRouter.js
+++ b/src/routers/driverRouter.js
@@ -1,0 +1,20 @@
+import { Driver } from '../driver.js';
+
+import express from 'express';
+const router = express.Router();
+
+const driver = new Driver();
+
+function getDrivers(req, res) {
+    res.send(['plex']);
+}
+
+function getLibrary(req, res) {
+    res.send('xxxx');
+}
+
+// Routes
+router.get('/', getDrivers);
+router.get('/library', getLibrary);
+
+export default router;

--- a/src/video.js
+++ b/src/video.js
@@ -1,12 +1,10 @@
-const express = require('express')
-const helperFuncs = require('./helperFuncs')
-const FFMPEG = require('./ffmpeg')
-const FFMPEG_TEXT = require('./ffmpegText')
-const fs = require('fs')
+import express from 'express';
+import * as helperFuncs from './helperFuncs.js';
+import * as FFMPEG from './ffmpeg.js';
+import * as FFMPEG_TEXT from './ffmpegText.js';
+import * as fs from 'fs';
 
-module.exports = { router: video }
-
-function video(db) {
+export default function video(db) {
     var router = express.Router()
 
     router.get('/setup', (req, res) => {

--- a/src/xmltv.js
+++ b/src/xmltv.js
@@ -1,8 +1,8 @@
-const XMLWriter = require('xml-writer')
-const fs = require('fs')
-const helperFuncs = require('./helperFuncs')
+import XMLWriter from 'xml-writer';
+import * as fs from 'fs';
+import * as helperFuncs from './helperFuncs.js';
 
-module.exports = { WriteXMLTV: WriteXMLTV }
+export default { WriteXMLTV: WriteXMLTV }
 
 function WriteXMLTV(channels, xmlSettings) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What has changed?
### Creating a database middleware.
For now, we use **diskdb** to save information, but, on future we may want to add new ways to save information, an **SQL**, plain **json** or simple change diskdb to **another lib**. Thinking on this, I'm created a **Database** class, to manager save, update, list and find. Without the other codes knowing which lib being in use.

### Driver Class & Driver Router
The concept behind The **Driver** is to manager information to client with multiple media-server, or any media-server type, like Emby, **Plex** or Jellyfin, without exclusivity.

The Driver can add media service on PseudoTv server without an exclusive service type.
The Driver possibility the channel end-point return a channel with multiple media sources or just without an exclusive service.

### ECMAScript Modules
Changed from `require` to `import`.
All modules are now exported by `export` and no more by `module.export`. 

Related with #20 and #19 