### PR TITLE
Fix misleading opts not defined error

### DIFF
--- a/src/ffmpeg.js
+++ b/src/ffmpeg.js
@@ -165,7 +165,7 @@ class FFMPEG extends events.EventEmitter {
             else if (code === 255)
                 this.emit('close', code)
             else
-                this.emit('error', { code: code, cmd: `${opts.ffmpegPath} ${tmpargs.join(' ')}` })
+                this.emit('error', { code: code, cmd: `${this.opts.ffmpegPath} ${tmpargs.join(' ')}` })
         })
     }
     kill() {


### PR DESCRIPTION
This fixes #42 , I'm not sure why that code was only reachable in docker in my case, it seems to be a different docker-speciifc issue that's reaching this if branch and the logs only reported the opts error.