### PR TITLE
Reorder Dockerfile commands to take better advantage of the Docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN apk add --no-cache ffmpeg && ffmpeg -version
 WORKDIR /home/node/app
 COPY package*.json ./
 RUN npm install
-COPY . .
 RUN npm install -g browserify
-RUN npm run build
 EXPOSE 8000
 CMD [ "npm", "start"]
+COPY . .
+RUN npm run build


### PR DESCRIPTION
This order change makes it so it doesn't have to download and install browserify every time  you build the docker image when the only change is in the source code files.