### PR TITLE
Fix 'unhandled exception' crash when there is a ffmpeg error after headers were sent

### DIFF
--- a/src/video.js
+++ b/src/video.js
@@ -74,7 +74,8 @@ function video(db) {
 
         ffmpeg.on('error', (err) => {
             console.error("FFMPEG ERROR", err);
-            res.status(500).send("FFMPEG ERROR");
+            //status was already sent
+            res.end();
             return;
         })
 


### PR DESCRIPTION
When there's a ffmpeg error, it currently attempts to send a 500 status code, but the problem is that at this point, the 200 code and content-type headers were already written. This causes an error about sending headers again.  And this unhandled error causes pseudo to crash.  This commit replaces the error status with ending the stream.