### PR TITLE
Deal with 'Cannot convert to below minimum bandwidth of' error.

### DIFF
--- a/src/plexTranscoder.js
+++ b/src/plexTranscoder.js
@@ -110,7 +110,12 @@ lang=en`
     }
 
     isVideoDirectStream() {
-        return this.decisionJson["MediaContainer"]["Metadata"][0]["Media"][0]["Part"][0]["Stream"][0]["decision"] == "copy";
+        try {
+            return this.decisionJson["MediaContainer"]["Metadata"][0]["Media"][0]["Part"][0]["Stream"][0]["decision"] == "copy";
+        } catch (e) {
+            console.log("Error at decision:" + e);
+            return false;
+        }
     }
 
     getResolutionHeight() {


### PR DESCRIPTION
Given some specific circumstances. Plex's decision will sometimes return an error "Cannot convert to below minimum bandwidth of" . I can reproduce it sometime with a video with codec different to h264 and audio codec aac, when my plex settings are h264 and aac. This seems to be a plex issue because all it needs to do is decide to transcode, but it returns an error about minimum bandwidth. This fix forces plex to transcode when there's this error and the stream can go on.