### PR TITLE
Plex file source options

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,8 @@ function initDB(db) {
 
     if (plexSettings.length === 0) {
         db['plex-settings'].save({
+            streamPath: 'plex',
+            debugLogging: true,
             directStreamBitrate: '40000',
             transcodeBitrate: '3000',
             mediaBufferSize: 1000,
@@ -127,13 +129,16 @@ function initDB(db) {
             maxPlayableResolution: "1920x1080",
             maxTranscodeResolution: "1920x1080",
             videoCodecs: 'h264,hevc,mpeg2video',
-            audioCodecs: 'ac3,aac,mp3',
-            maxAudioChannels: '6',
+            audioCodecs: 'ac3',
+            maxAudioChannels: '2',
             audioBoost: '100',
             enableSubtitles: false,
             subtitleSize: '100',
             updatePlayStatus: false,
-            streamProtocol: 'http'
+            streamProtocol: 'http',
+            forceDirectPlay: false,
+            pathReplace: '',
+            pathReplaceWith: ''
         })
     }
 

--- a/src/api.js
+++ b/src/api.js
@@ -89,6 +89,8 @@ function api(db, xmltvInterval) {
     })
     router.post('/api/plex-settings', (req, res) => { // RESET
         db['plex-settings'].update({ _id: req.body._id }, {
+            streamPath: 'plex',
+            debugLogging: true,
             directStreamBitrate: '40000',
             transcodeBitrate: '3000',
             mediaBufferSize: 1000,
@@ -96,13 +98,16 @@ function api(db, xmltvInterval) {
             maxPlayableResolution: "1920x1080",
             maxTranscodeResolution: "1920x1080",
             videoCodecs: 'h264,hevc,mpeg2video',
-            audioCodecs: 'ac3,aac,mp3',
-            maxAudioChannels: '6',
+            audioCodecs: 'ac3',
+            maxAudioChannels: '2',
             audioBoost: '100',
             enableSubtitles: false,
             subtitleSize: '100',
             updatePlayStatus: false,
-            streamProtocol: 'http'
+            streamProtocol: 'http',
+            forceDirectPlay: false,
+            pathReplace: '',
+            pathReplaceWith: ''
         })
         let plex = db['plex-settings'].find()[0]
         res.send(plex)

--- a/src/ffmpeg.js
+++ b/src/ffmpeg.js
@@ -9,13 +9,24 @@ class FFMPEG extends events.EventEmitter {
         this.channel = channel
         this.ffmpegPath = opts.ffmpegPath
     }
-    async spawn(streamUrl, streamStats, duration, enableIcon, type, isConcatPlaylist) {
+    async spawnConcat(streamUrl) {
+        this.spawn(streamUrl, undefined, undefined, undefined, false, false, undefined, true)
+    }
+    async spawnStream(streamUrl, streamStats, startTime, duration, enableIcon, type) {
+        this.spawn(streamUrl, streamStats, startTime, duration, true, enableIcon, type, false)
+    }
+    async spawn(streamUrl, streamStats, startTime, duration, limitRead, enableIcon, type, isConcatPlaylist) {
         let ffmpegArgs = [`-threads`, this.opts.threads,
-                          `-re`,
                           `-fflags`, `+genpts+discardcorrupt+igndts`];
         
-        if (duration > 0)
+        if (limitRead === true)
+            ffmpegArgs.push(`-re`)
+        
+        if (typeof duration !== 'undefined')
             ffmpegArgs.push(`-t`, duration)
+
+        if (typeof startTime !== 'undefined')
+            ffmpegArgs.push(`-ss`, startTime)
         
         if (isConcatPlaylist == true)
             ffmpegArgs.push(`-f`, `concat`, 

--- a/src/helperFuncs.js
+++ b/src/helperFuncs.js
@@ -50,6 +50,8 @@ function createLineup(obj) {
                 lineup.push({
                     type: 'commercial',
                     key: commercials[i][y].key,
+                    plexFile: commercials[i][y].plexFile,
+                    file: commercials[i][y].file,
                     ratingKey: commercials[i][y].ratingKey,
                     start: timeElapsed, // start time will be the time elapsed, cause this is the first video
                     streamDuration: commercials[i][y].duration - timeElapsed, // stream duration set accordingly
@@ -60,6 +62,8 @@ function createLineup(obj) {
                 lineup.push({   // just add the video, starting at 0, playing the entire duration
                     type: 'commercial',
                     key: commercials[i][y].key,
+                    plexFile: commercials[i][y].plexFile,
+                    file: commercials[i][y].file,
                     ratingKey: commercials[i][y].ratingKey,
                     start: 0,
                     streamDuration: commercials[i][y].actualDuration,
@@ -76,6 +80,8 @@ function createLineup(obj) {
                 lineup.push({
                     type: 'program',
                     key: activeProgram.key,
+                    plexFile: activeProgram.plexFile,
+                    file: activeProgram.file,
                     ratingKey: activeProgram.ratingKey,
                     start: progTimeElapsed + timeElapsed, // add the duration of already played program chunks to the timeElapsed
                     streamDuration: (programStartTimes[i + 1] - programStartTimes[i]) - timeElapsed,
@@ -89,6 +95,8 @@ function createLineup(obj) {
                     lineup.push({
                         type: 'program',
                         key: activeProgram.key,
+                        plexFile: activeProgram.plexFile,
+                        file: activeProgram.file,
                         ratingKey: activeProgram.ratingKey,
                         start: programStartTimes[i],
                         streamDuration: (programStartTimes[i + 1] - programStartTimes[i]),

--- a/web/directives/plex-settings.js
+++ b/web/directives/plex-settings.js
@@ -53,6 +53,16 @@ module.exports = function (plex, pseudotv, $timeout) {
                     scope.settings = _settings
                 })
             }
+            scope.pathOptions=[
+                {id:"plex",description:"Plex"},
+                {id:"direct",description:"Direct"}
+            ];
+            scope.hideIfNotPlexPath = () => {
+                return scope.settings.streamPath != 'plex'
+            };
+            scope.hideIfNotDirectPath = () => {
+                return scope.settings.streamPath != 'direct'
+            };
             scope.maxAudioChannelsOptions=[
                 {id:"1",description:"1.0"},
                 {id:"2",description:"2.0"},

--- a/web/public/templates/plex-settings.html
+++ b/web/public/templates/plex-settings.html
@@ -55,6 +55,29 @@
 </h6>
 <hr>
 <div class="row" >
+    <div class="col-sm-3">
+        <div class="form-group">
+            <input id="debugLogging" type="checkbox" ng-model="settings.debugLogging"/>
+            <label for="debugLogging">Debug logging</label>
+        </div>
+        <div class="form-group">
+            <label>Paths</label>
+            <select ng-model="settings.streamPath" 
+                ng-options="o.id as o.description for o in pathOptions" />
+        </div>
+    </div>
+    <div class="col-sm-3">
+        <div class="form-group">
+            <input id="updatePlayStatus" type="checkbox" ng-model="settings.updatePlayStatus" ria-describedby="updatePlayStatusHelp"/>
+            <label for="updatePlayStatus">Send play status to Plex</label>
+            <small id="updatePlayStatusHelp" class="form-text text-muted">Note: This affects the "on deck" for your plex account.</small>
+        </div>
+    </div>
+    <div class="col-sm-6">
+        <p class="text-center text-danger">If stream changes video codec, audio codec, or audio channels upon episode change, you will experience playback issues.</p>
+    </div>
+</div>
+<div class="row" ng-hide="hideIfNotPlexPath()">
     <div class="col-sm-6">
         <h6 style="font-weight: bold">Video Options</h6>
         <div class="form-group">
@@ -76,7 +99,8 @@
         <h6 style="font-weight: bold">Audio Options</h6>
         <div class="form-group">
             <label>Supported Audio Formats</label>
-            <input type="text" class="form-control form-control-sm" ng-model="settings.audioCodecs" />
+            <input type="text" class="form-control form-control-sm" ng-model="settings.audioCodecs" ria-describedby="audioCodecsHelp" />
+            <small id="audioCodecsHelp" class="form-text text-muted">Comma separated list. Some possible values are 'ac3,aac,mp3'.</small>
         </div>
         <div class="form-group">
             <label>Maximum Audio Channels</label>
@@ -92,7 +116,7 @@
         </div>
     </div>
 </div>
-<div class="row">
+<div class="row" ng-hide="hideIfNotPlexPath()">
     <div class="col-sm-6">
         <h6 style="font-weight: bold">Miscellaneous Options</h6>
         <div class="form-group">
@@ -112,14 +136,13 @@
             <input type="text" class="form-control form-control-sm" ng-model="settings.transcodeMediaBufferSize" />
         </div>
         <div class="form-group">
-            <input id="updatePlayStatus" type="checkbox" ng-model="settings.updatePlayStatus" ria-describedby="updatePlayStatusHelp"/>
-            <label for="updatePlayStatus">Send play status to Plex when possible</label>
-            <small id="updatePlayStatusHelp" class="form-text text-muted">Note: This affects the "on deck" for your plex account.</small>
-        </div>
-        <div class="form-group">
             <label>Stream Protocol</label>
             <select ng-model="settings.streamProtocol" 
                 ng-options="o.id as o.description for o in streamProtocols" />
+        </div>
+        <div class="form-group">
+            <input id="updatePlayStatus" type="checkbox" ng-model="settings.forceDirectPlay" />
+            <label for="updatePlayStatus">Force Direct Play</label>
         </div>
     </div>
     <div class="col-sm-6">
@@ -134,5 +157,16 @@
         </div>
     </div>
 </div>
-
+<div class="row" ng-hide="hideIfNotDirectPath()">
+    <div class="col-sm-6">
+        <h6 style="font-weight: bold">Path Replacements</h6>
+        <div class="form-group">
+            <label>Original Plex path to replace:</label>
+            <input type="text" class="form-control form-control-sm" ng-model="settings.pathReplace" />
+        </div>
+        <div class="form-group">
+            <label>Replace Plex path with:</label>
+            <input type="text" class="form-control form-control-sm" ng-model="settings.pathReplaceWith" />
+        </div>
+    </div>
 </div>

--- a/web/services/plex.js
+++ b/web/services/plex.js
@@ -146,6 +146,10 @@ module.exports = function ($http, $window, $interval) {
                     date: res.Metadata[i].originallyAvailableAt,
                     year: res.Metadata[i].year,
                 }
+                if (program.type === 'episode' || program.type === 'movie') {
+                    program.plexFile = `${res.Metadata[i].Media[0].Part[0].key}`
+                    program.file = `${res.Metadata[i].Media[0].Part[0].file}`
+                }
                 if (program.type === 'episode') {
                     //Make sure that video files that contain multiple episodes are only listed once:
                     var anyNewFile = false;


### PR DESCRIPTION
Add plex options to pick between plex paths and direct paths. Change ffmpeg concat to always read in at fastest rate possible. /stream endpoint will now always spawn a seperate ffmpeg process now, no longer redirects sometimes. Plex transcoder has ability to update play status regardless of direct/plex paths. Add debug logging.