### PR TITLE
Audio channel/sampleRate normalization. Tweaks to ffmpeg config

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,8 +109,15 @@ function initDB(db) {
         fs.writeFileSync(process.env.DATABASE + '/images/generic-error-screen.png', data)
     }
 
-    if ( (ffmpegSettings.length === 0) || typeof(ffmpegSettings.configVersion) === 'undefined' ) {
-        db['ffmpeg-settings'].save( defaultSettings.ffmpeg() )
+    var ffmpegRepaired = defaultSettings.repairFFmpeg(ffmpegSettings);
+    if (ffmpegRepaired.hasBeenRepaired) {
+        var fixed = ffmpegRepaired.fixedConfig;
+        var i = fixed._id;
+        if ( i == null || typeof(i) == 'undefined') {
+            db['ffmpeg-settings'].save(fixed);
+        } else {
+            db['ffmpeg-settings'].update( { _id: i } , fixed );
+        }
     }
 
     if (plexSettings.length === 0) {

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -1,6 +1,4 @@
-module.exports = {
-
-    ffmpeg: () => {
+    function ffmpeg() {
         return {
             //a record of the config version will help migrating between versions
             // in the future. Always increase the version when new ffmpeg configs
@@ -8,7 +6,7 @@ module.exports = {
             //
             // configVersion 3: First versioned config.
             //
-            configVersion: 3,
+            configVersion: 4,
             ffmpegPath: "/usr/bin/ffmpeg",
             threads: 4,
             concatMuxDelay: "0",
@@ -20,12 +18,56 @@ module.exports = {
             targetResolution: "1920x1080",
             videoBitrate: 10000,
             videoBufSize: 2000,
+            audioBitrate: 192,
+            audioBufSize: 50,
+            audioSampleRate: 48,
+            audioChannels: 2,
             errorScreen: "pic",
             errorAudio: "silent",
             normalizeVideoCodec: false,
             normalizeAudioCodec: false,
             normalizeResolution: false,
-            alignAudio: false,
+            normalizeAudio: false,
         }
     }
+
+    function repairFFmpeg(existingConfigs) {
+        var hasBeenRepaired = false;
+        var currentConfig = {};
+        var _id = null;
+        if (existingConfigs.length === 0) {
+            currentConfig = {};
+        } else {
+            currentConfig = existingConfigs[0];
+            _id = currentConfig._id;
+        }
+        if (
+            (typeof(currentConfig.configVersion) === 'undefined')
+            || (currentConfig.configVersion < 3)
+        ) {
+            hasBeenRepaired = true;
+            currentConfig = ffmpeg();
+            currentConfig._id = _id;
+        }
+        if (currentConfig.configVersion == 3) {
+            //migrate from version 3 to 4
+            hasBeenRepaired = true;
+            //new settings:
+            currentConfig.audioBitrate = 192;
+            currentConfig.audioBufSize = 50;
+            currentConfig.audioChannels = 2;
+            currentConfig.audioSampleRate = 48;
+            //this one has been renamed:
+            currentConfig.normalizeAudio = currentConfig.alignAudio;
+            currentConfig.configVersion = 4;
+        }
+        return {
+            hasBeenRepaired: hasBeenRepaired,
+            fixedConfig : currentConfig,
+        };
+    }
+
+module.exports = {
+    ffmpeg: ffmpeg,
+    repairFFmpeg: repairFFmpeg,
 }

--- a/src/video.js
+++ b/src/video.js
@@ -199,7 +199,6 @@ function video(db) {
 
             let streamStats = stream.streamStats;
             streamStats.duration = lineupItem.streamDuration;
-            console.log("timeElapsed=" + prog.timeElapsed );
 
             this.backup = {
                 stream: stream,

--- a/web/directives/ffmpeg-settings.js
+++ b/web/directives/ffmpeg-settings.js
@@ -20,7 +20,7 @@
                 })
             }
             scope.isTranscodingNotNeeded = () => {
-                return ! (scope.settings.enableFFMPEGTranscoding)
+                return (typeof(scope.settings) ==='undefined') || ! (scope.settings.enableFFMPEGTranscoding);
             };
             scope.hideIfNotAutoPlay = () => {
                 return scope.settings.enableAutoPlay != true

--- a/web/public/templates/ffmpeg-settings.html
+++ b/web/public/templates/ffmpeg-settings.html
@@ -93,9 +93,21 @@
         </div>
 
         <div class="form-group">
+            <label>Audio Bitrate (k)</label>
+            <input type="number" class="form-control form-control-sm" ng-model="settings.audioBitrate"/>
+            <br />
+            <label>Audio Buffer Size (k)</label>
+            <input type="number" class="form-control form-control-sm" ng-model="settings.audioBufSize"/>
+            <br />
             <label>Audio Volume (%)</label>
             <input type="number" ria-describedby="volumeHelp" class="form-control form-control-sm" ng-model="settings.audioVolumePercent"/>
             <small id="volumeHelp" class="form-text text-muted">Values higher than 100 will boost the audio.</small>
+            <br />
+            <label>Audio Channels</label>
+            <input type="number" class="form-control form-control-sm" ng-model="settings.audioChannels"/>
+            <br />
+            <label>Audio Sample Rate (k)</label>
+            <input type="number" class="form-control form-control-sm" ng-model="settings.audioSampleRate"/>
         </div>
 
 
@@ -146,9 +158,9 @@
         <div class="row">
             <div class="col-sm-9">
                 <div class="form-group">
-                    <input id="enableAlignAudio" type="checkbox" ng-model="settings.alignAudio" ng-disabled="isTranscodingNotNeeded()" />
-                    <label for="enableAlignAudio">Align Audio and Video lengths</label>
-                    <small class="form-text text-muted">In rare situations, video and audio streams in a video may have different lengths. This can cause desync issues in some clients. This transcodes audio in all videos to ensure the lengths stay the same.
+                    <input id="enableAlignAudio" type="checkbox" ng-model="settings.normalizeAudio" ng-disabled="isTranscodingNotNeeded()" />
+                    <label for="enableAlignAudio">Normalize Audio</label>
+                    <small class="form-text text-muted">This will force the preferred number of audio channels and sample rate, in addition it will align the lengths of the audio and video channels. This will prevent audio-related episode transition issues in many clients. Audio will always be transcoded.
                     </small>
                 </div>
             </div>


### PR DESCRIPTION
* In some clients (specifically tivimate and emby's live TV support), concatenating streams with different audio sample rate or channel count an cause audio distortion. This normalizes it. This feature is merged with old align audio because these two features are about preventing channel stream issues and both (currently) mean that audio will always be encoded.

* Fix ffmpeg config load issues. In the past version I made some mistakes about how ffmpeg configuration is initialized (specifically, I didn't know the filedb thing saved it as an array instead of directly as an object). I think this would explain some bug reports about settings getting deleted.

* As part of adding those new audio settings , this upgrades ffmpeg configuration to version 4. And there's logic to fix up version 3 to this version so that it is not necessary to reset the ffmpeg configuration if you already had the previous version. Also config should be reset automatically if you are upgrading from an even older version

* Raise beep volume a bit. -72db was probably too much and I can barely hear it in most of my clients, so I am raising it a bit.