### PR TITLE
Fix xmltv date bug with some time zones. Improve error message when it's not possible to call plex DVRs endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ let xmltvInterval = {
                         plex.RefreshGuide(dvrs).then(() => { }, (err) => { console.error(err, i) })
                     if (plexServers[i].arChannels && channels.length !== 0)
                         plex.RefreshChannels(channels, dvrs).then(() => { }, (err) => { console.error(err, i) })
-                })
+                }).catch( (err) => {
+                    console.error("There was an error when fetching Plex DVRs. This means pseudoTV couldn't trigger Plex to update its TV guide." + err);
+                });
             }
         }, (err) => {
             console.error("Failed to write the xmltv.xml file. Something went wrong. Check your output directory via the web UI and verify file permissions?", err)

--- a/src/xmltv.js
+++ b/src/xmltv.js
@@ -135,13 +135,5 @@ function _writeProgramme(xw, program) {
     xw.endElement()
 }
 function _createXMLTVDate(d) {
-    function pad(n) { return n < 10 ? '0' + n : n }
-    var timezone = d.toString().split('GMT')
-    timezone = timezone[timezone.length - 1].split(' ')[0]
-    return d.getFullYear() + ""
-        + pad(d.getMonth() + 1) + ""
-        + pad(d.getDate()) + ""
-        + pad(d.getHours()) + ""
-        + pad(d.getMinutes()) + ""
-        + pad(d.getSeconds()) + " " + timezone
+    return d.toISOString().substring(0,19).replace(/[-T:]/g,"") + " +0000";
 }


### PR DESCRIPTION
This is a bug reported in the support channel. Running pseudo at certain timezones causes the xmltv to generate malforned start/end times like "20200706192319 +02:00)" . I was able to reproduce it by adding:

```
    environment:
      - TZ="America/La Paz"
```

To my docker-compose entry. The new code takes advantage of the ISO date conversion which handles the ordering and forces UTC time.

There's also a small fix to an error log that keeps popping up from time to time when you don't have access to the DVRs endpoint in plex.

